### PR TITLE
Fix CI by installing pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run-install: false
       - name: Install
-        run: corepack enable && pnpm i
+        run: pnpm install
       - name: Lint
         run: pnpm lint
       - name: Test


### PR DESCRIPTION
## Summary
- use `pnpm/action-setup` in workflow

## Testing
- `pnpm lint` *(fails: all files ignored)*
- `pnpm test` *(fails: cannot find module 'nock')*

------
https://chatgpt.com/codex/tasks/task_e_683f1651f1748330b9805eb918c72a7b