### PR TITLE
Implement item_state table

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "concurrently -n client,server -c green,cyan \"pnpm --filter client dev\" \"pnpm --filter server dev\"",
     "lint": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
     "test": "jest",
-    "seed": "pnpm --filter server prisma db push && ts-node --esm server/prisma/seed.ts"
+    "seed": "pnpm --filter server exec prisma db push && pnpm exec tsx server/prisma/seed.ts"
   },
   "devDependencies": {
     "@types/cors": "^2.8.18",
@@ -27,6 +27,8 @@
     "prettier": "^3.5.3",
     "supertest": "^7.1.1",
     "ts-jest": "^29.3.4",
-    "ts-node-dev": "^2.0.0"
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "tsx": "^4.19.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,15 @@ importers:
       ts-jest:
         specifier: ^29.3.4
         version: 29.3.4(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(jest@29.7.0(@types/node@22.15.29)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.15.29)(typescript@5.8.3)
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.15.29)(typescript@5.8.3)
+      tsx:
+        specifier: ^4.19.4
+        version: 4.19.4
 
   client:
     devDependencies:
@@ -67,7 +73,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.29)
+        version: 6.3.5(@types/node@22.15.29)(tsx@4.19.4)
 
   server:
     dependencies:
@@ -1479,6 +1485,9 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -2152,6 +2161,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
@@ -2422,6 +2434,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.19.4:
+    resolution: {integrity: sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4118,6 +4135,10 @@ snapshots:
 
   get-stream@6.0.1: {}
 
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -4891,6 +4912,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve.exports@2.0.3: {}
 
   resolve@1.22.10:
@@ -5200,6 +5223,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.19.4:
+    dependencies:
+      esbuild: 0.25.5
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -5245,7 +5275,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@6.3.5(@types/node@22.15.29):
+  vite@6.3.5(@types/node@22.15.29)(tsx@4.19.4):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.5(picomatch@4.0.2)
@@ -5256,6 +5286,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.15.29
       fsevents: 2.3.3
+      tsx: 4.19.4
 
   walker@1.0.8:
     dependencies:

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -8,33 +8,52 @@ generator client {
 }
 
 model User {
-  id      Int      @id @default(autoincrement())
-  uuid    String   @unique
-  reviews Review[]
+  id         Int         @id @default(autoincrement())
+  uuid       String      @unique
+  reviews    Review[]
+  itemStates ItemState[]
 }
 
 model Item {
-  id          Int       @id @default(autoincrement())
+  id          Int         @id @default(autoincrement())
   objectiveId Int
   tier        Int
   stem        String
-  reference   Json
-  Objective   Objective @relation(fields: [objectiveId], references: [id])
+  reference   String
+  Objective   Objective   @relation(fields: [objectiveId], references: [id])
+  states      ItemState[]
+  reviews     Review[]
 }
 
 model Review {
-  id      Int   @id @default(autoincrement())
+  id      Int      @id @default(autoincrement())
   userId  Int
   itemId  Int
   ts      DateTime @default(now())
   verdict String
   score   Float
-  Item    Item @relation(fields: [itemId], references: [id])
-  User    User @relation(fields: [userId], references: [id])
+  Item    Item     @relation(fields: [itemId], references: [id])
+  User    User     @relation(fields: [userId], references: [id])
+}
+
+model ItemState {
+  id         Int      @id @default(autoincrement())
+  userId     Int
+  itemId     Int
+  stability  Float
+  difficulty Float
+  ease       Float
+  lastReview DateTime @default(now())
+  nextDue    DateTime
+  p_recall   Float
+  Item       Item     @relation(fields: [itemId], references: [id])
+  User       User     @relation(fields: [userId], references: [id])
+
+  @@unique([userId, itemId])
 }
 
 model ObjectiveState {
-  id          Int  @id @default(autoincrement())
+  id          Int     @id @default(autoincrement())
   userId      Int
   objectiveId Int
   p_mastery   Float
@@ -42,7 +61,7 @@ model ObjectiveState {
 }
 
 model ClusterState {
-  id        Int  @id @default(autoincrement())
+  id        Int     @id @default(autoincrement())
   userId    Int
   clusterId Int
   unlocked  Boolean @default(false)

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -20,7 +20,7 @@ async function main() {
               data: Array.from({ length: 3 }).map((__, j) => ({
                 tier: 1,
                 stem: `Seed stem C${i + 1}-${j + 1}`,
-                reference: { answer: 'demo' }
+                reference: JSON.stringify({ answer: 'demo' })
               }))
             }
           }


### PR DESCRIPTION
## Summary
- implement `ItemState` model in Prisma schema
- connect users and items to item state records
- store answer reference as string in items
- adjust seed script to handle reference strings
- add ts-node dev dependency to run seeds
- run seed with **tsx** instead of ts-node

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm seed`

------
https://chatgpt.com/codex/tasks/task_e_683f97b6ff748330bec281246ecad405