### PR TITLE
Add objective extractor API

### DIFF
--- a/server/__tests__/extract.test.ts
+++ b/server/__tests__/extract.test.ts
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import nock from 'nock';
+import fs from 'fs/promises';
+import path from 'path';
+import { app } from '../src/index';
+
+const samplePath = path.join(__dirname, 'fixtures', 'sample.txt');
+
+beforeEach(() => {
+  nock.cleanAll();
+});
+
+ test('objective extractor returns list', async () => {
+  const text = await fs.readFile(samplePath, 'utf8');
+  nock('https://api.deepseek.com')
+    .post('/v1/chat/completions')
+    .reply(200, {
+      choices: [{ message: { content: JSON.stringify(['a','b','c','d','e']) } }]
+    });
+
+  const res = await request(app)
+    .post('/api/objectives/extract')
+    .send({ text });
+
+  expect(res.status).toBe(200);
+  expect(res.body.objectives.length).toBeGreaterThanOrEqual(5);
+});
+

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import { Env } from './env';
 import { hello } from '../../shared/src';
 import { saveText } from './upload';
+import { extractObjectives } from './objectives';
 
 // Express server exposing health check and upload route.
 export const app = express();
@@ -16,6 +17,20 @@ app.post('/api/upload', async (req, res) => {
   }
   const uploadId = await saveText(text);
   res.status(201).json({ upload_id: uploadId });
+});
+
+app.post('/api/objectives/extract', async (req, res) => {
+  const text = req.body.text;
+  if (typeof text !== 'string' || !text.trim()) {
+    return res.status(400).json({ error: 'text required' });
+  }
+  try {
+    const objectives = await extractObjectives(text);
+    res.json({ objectives });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'llm_error' });
+  }
 });
 
 app.get('/health', (_, res) => res.json({ status: 'ok', msg: hello() }));

--- a/server/src/objectives.ts
+++ b/server/src/objectives.ts
@@ -1,0 +1,28 @@
+import { deepSeekChat } from './llm/deepseek';
+
+export async function extractObjectives(text: string): Promise<string[]> {
+  const system =
+    'You are an expert learning designer. Extract a concise list of learning objectives from the provided text. Return only a JSON array of short objectives.';
+  const body = {
+    model: 'deepseek-chat',
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: text }
+    ],
+    temperature: 0
+  };
+
+  const res = await deepSeekChat(body);
+  const content = res.choices?.[0]?.message?.content ?? '[]';
+  let list: unknown = [];
+  try {
+    list = JSON.parse(content);
+  } catch {
+    throw new Error('invalid JSON');
+  }
+  if (!Array.isArray(list)) {
+    throw new Error('invalid response');
+  }
+  return list as string[];
+}
+


### PR DESCRIPTION
## Summary
- implement `extractObjectives` using DeepSeek
- expose `/api/objectives/extract` route
- test objective extraction route

## Testing
- `pnpm lint`
- `pnpm exec jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_683fbd76e66c833090c5b12158171ff8