### PR TITLE
feat: typed db helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "jest",
     "seed": "pnpm --filter server exec prisma db push && pnpm exec tsx server/prisma/seed.ts"
   },
-  "postinstall": "pnpm --filter server exec prisma generate",
   "devDependencies": {
     "@types/cors": "^2.8.18",
     "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "jest",
     "seed": "pnpm --filter server exec prisma db push && pnpm exec tsx server/prisma/seed.ts"
   },
+  "postinstall": "pnpm --filter server exec prisma generate",
   "devDependencies": {
     "@types/cors": "^2.8.18",
     "@types/jest": "^29.5.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,11 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.15.29)(typescript@5.8.3)
 
-  shared: {}
+  shared:
+    dependencies:
+      '@prisma/client':
+        specifier: ^5.6.0
+        version: 5.22.0(prisma@5.22.0)
 
 packages:
 

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "dev": "ts-node-dev --respawn src/index.ts"
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "express": "^4.18.3",

--- a/shared/__tests__/db.test.ts
+++ b/shared/__tests__/db.test.ts
@@ -1,0 +1,12 @@
+import { user, db } from '../db';
+
+afterAll(async () => {
+  await db.$disconnect();
+});
+
+test('create and fetch typed user', async () => {
+  const u = await user.create({ data: { uuid: 'test-uuid' } });
+  const fetched = await user.find({ id: u.id });
+  expect(fetched?.uuid).toBe('test-uuid');
+  await user.remove({ id: u.id });
+});

--- a/shared/__tests__/db.test.ts
+++ b/shared/__tests__/db.test.ts
@@ -1,4 +1,11 @@
 import { user, db } from '../db';
+import { execSync } from 'child_process';
+
+beforeAll(() => {
+  execSync('pnpm --filter server exec prisma db push --skip-generate', {
+    stdio: 'inherit'
+  });
+});
 
 afterAll(async () => {
   await db.$disconnect();

--- a/shared/db.ts
+++ b/shared/db.ts
@@ -1,0 +1,56 @@
+import { PrismaClient, Prisma } from '@prisma/client';
+
+export const db = new PrismaClient();
+
+export const user = {
+  create: (args: Prisma.UserCreateArgs) => db.user.create(args),
+  find: (where: Prisma.UserWhereUniqueInput) => db.user.findUnique({ where }),
+  update: (args: Prisma.UserUpdateArgs) => db.user.update(args),
+  remove: (where: Prisma.UserWhereUniqueInput) => db.user.delete({ where }),
+};
+
+export const item = {
+  create: (args: Prisma.ItemCreateArgs) => db.item.create(args),
+  find: (where: Prisma.ItemWhereUniqueInput) => db.item.findUnique({ where }),
+  update: (args: Prisma.ItemUpdateArgs) => db.item.update(args),
+  remove: (where: Prisma.ItemWhereUniqueInput) => db.item.delete({ where }),
+};
+
+export const review = {
+  create: (args: Prisma.ReviewCreateArgs) => db.review.create(args),
+  find: (where: Prisma.ReviewWhereUniqueInput) => db.review.findUnique({ where }),
+  update: (args: Prisma.ReviewUpdateArgs) => db.review.update(args),
+  remove: (where: Prisma.ReviewWhereUniqueInput) => db.review.delete({ where }),
+};
+
+export const itemState = {
+  create: (args: Prisma.ItemStateCreateArgs) => db.itemState.create(args),
+  find: (where: Prisma.ItemStateWhereUniqueInput) => db.itemState.findUnique({ where }),
+  update: (args: Prisma.ItemStateUpdateArgs) => db.itemState.update(args),
+  remove: (where: Prisma.ItemStateWhereUniqueInput) => db.itemState.delete({ where }),
+};
+
+export const objectiveState = {
+  create: (args: Prisma.ObjectiveStateCreateArgs) => db.objectiveState.create(args),
+  find: (where: Prisma.ObjectiveStateWhereUniqueInput) =>
+    db.objectiveState.findUnique({ where }),
+  update: (args: Prisma.ObjectiveStateUpdateArgs) => db.objectiveState.update(args),
+  remove: (where: Prisma.ObjectiveStateWhereUniqueInput) =>
+    db.objectiveState.delete({ where }),
+};
+
+export const clusterState = {
+  create: (args: Prisma.ClusterStateCreateArgs) => db.clusterState.create(args),
+  find: (where: Prisma.ClusterStateWhereUniqueInput) =>
+    db.clusterState.findUnique({ where }),
+  update: (args: Prisma.ClusterStateUpdateArgs) => db.clusterState.update(args),
+  remove: (where: Prisma.ClusterStateWhereUniqueInput) =>
+    db.clusterState.delete({ where }),
+};
+
+export const objective = {
+  create: (args: Prisma.ObjectiveCreateArgs) => db.objective.create(args),
+  find: (where: Prisma.ObjectiveWhereUniqueInput) => db.objective.findUnique({ where }),
+  update: (args: Prisma.ObjectiveUpdateArgs) => db.objective.update(args),
+  remove: (where: Prisma.ObjectiveWhereUniqueInput) => db.objective.delete({ where }),
+};

--- a/shared/package.json
+++ b/shared/package.json
@@ -2,5 +2,8 @@
   "name": "shared",
   "private": true,
   "version": "0.1.0",
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "dependencies": {
+    "@prisma/client": "^5.6.0"
+  }
 }


### PR DESCRIPTION
## Summary
- expose typed CRUD helpers for Prisma models in `shared/db.ts`
- add tests verifying typed objects
- include `@prisma/client` dependency for shared package

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc953f8248330a84fb94059a79fc2