### PR TITLE
feat: add ensemble free response grader

### DIFF
--- a/server/__tests__/grader.test.ts
+++ b/server/__tests__/grader.test.ts
@@ -1,0 +1,59 @@
+import { gradeFreeResponse } from '../src/llm/grader';
+import { deepSeekChat } from '../src/llm/deepseek';
+
+jest.mock('../src/llm/deepseek', () => ({
+  deepSeekChat: jest.fn()
+}));
+
+const mockChat = deepSeekChat as jest.Mock;
+
+beforeEach(() => {
+  mockChat.mockReset();
+});
+
+test('majority vote returns final verdict', async () => {
+  mockChat
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"correct"}' } }] })
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"incorrect"}' } }] })
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"correct"}' } }] });
+
+  const res = await gradeFreeResponse('Q', 'A');
+  expect(res.verdict).toBe('correct');
+  expect(res.score).toBe(1);
+  expect(res.modelVotes).toEqual(['correct', 'incorrect', 'correct']);
+  expect(mockChat).toHaveBeenCalledTimes(3);
+});
+
+test('unsure triggers escalate', async () => {
+  mockChat
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"partial"}' } }] })
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"unsure"}' } }] })
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"incorrect"}' } }] });
+
+  const res = await gradeFreeResponse('Q', 'A');
+  expect(res.verdict).toBe('escalate');
+  expect(res.score).toBeNull();
+});
+
+test('majority partial returns score 0.6', async () => {
+  mockChat
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"partial"}' } }] })
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"partial"}' } }] })
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"incorrect"}' } }] });
+
+  const res = await gradeFreeResponse('Q', 'A');
+  expect(res.verdict).toBe('partial');
+  expect(res.score).toBe(0.6);
+  expect(res.modelVotes).toEqual(['partial', 'partial', 'incorrect']);
+});
+
+test('all different verdicts escalate', async () => {
+  mockChat
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"correct"}' } }] })
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"partial"}' } }] })
+    .mockResolvedValueOnce({ choices: [{ message: { content: '{"verdict":"incorrect"}' } }] });
+
+  const res = await gradeFreeResponse('Q', 'A');
+  expect(res.verdict).toBe('escalate');
+  expect(res.score).toBeNull();
+});

--- a/server/src/llm/grader.ts
+++ b/server/src/llm/grader.ts
@@ -1,0 +1,82 @@
+import { deepSeekChat } from './deepseek';
+import { freeResponseGraderPrompt } from './prompts/freeResponseGrader';
+
+export type ModelVerdict =
+  | 'correct'
+  | 'partial'
+  | 'incorrect'
+  | 'blank'
+  | 'unsure';
+export type Verdict = 'correct' | 'partial' | 'incorrect' | 'blank' | 'escalate';
+export interface GradeResult {
+  verdict: Verdict;
+  score: number | null;
+  modelVotes: ModelVerdict[];
+  feedback?: string;
+  explanation?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reference?: any;
+}
+
+
+function parse(content: string) {
+  try {
+    return JSON.parse(content) as {
+      verdict?: ModelVerdict;
+      feedback?: string;
+      explanation?: string;
+      reference?: unknown;
+    };
+  } catch {
+    return {};
+  }
+}
+
+export async function gradeFreeResponse(prompt: string, answer: string): Promise<GradeResult> {
+  const body = {
+    model: 'deepseek-chat',
+    messages: [
+      { role: 'system', content: freeResponseGraderPrompt },
+      { role: 'user', content: `Prompt: ${prompt}\nAnswer: ${answer}` }
+    ],
+    temperature: 0
+  };
+
+  const results = await Promise.all([deepSeekChat(body), deepSeekChat(body), deepSeekChat(body)]);
+
+  const parsed = results.map((r) => {
+    const text = r.choices?.[0]?.message?.content ?? '{}';
+    return parse(text);
+  });
+
+  const votes = parsed.map((p) => (p.verdict ?? 'incorrect')) as ModelVerdict[];
+
+  if (votes.includes('unsure')) {
+    return { verdict: 'escalate', score: null, modelVotes: votes };
+  }
+
+  const counts: Record<string, number> = {};
+  for (const v of votes) counts[v] = (counts[v] ?? 0) + 1;
+
+  const majorityVerdict = Object.entries(counts).sort((a, b) => b[1] - a[1])[0];
+  if (!majorityVerdict || majorityVerdict[1] < 2) {
+    return { verdict: 'escalate', score: null, modelVotes: votes };
+  }
+
+  const finalVerdict = majorityVerdict[0] as Verdict;
+  const firstMajority = parsed[votes.indexOf(finalVerdict as ModelVerdict)];
+  let score: number | null = null;
+  if (finalVerdict === 'correct') score = 1.0;
+  else if (finalVerdict === 'partial') score = 0.6;
+  else if (finalVerdict === 'incorrect' || finalVerdict === 'blank') score = 0.0;
+
+  return {
+    verdict: finalVerdict,
+    score,
+    modelVotes: votes,
+    feedback: firstMajority?.feedback,
+    explanation: firstMajority?.explanation,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    reference: firstMajority?.reference as any
+  };
+}

--- a/server/src/llm/prompts/freeResponseGrader.ts
+++ b/server/src/llm/prompts/freeResponseGrader.ts
@@ -1,0 +1,1 @@
+export const freeResponseGraderPrompt = `You are a strict grader. Evaluate the user's answer to the prompt and return JSON {"verdict": "correct|partial|incorrect|blank|unsure", "feedback": "..."}. Only respond with JSON.`;


### PR DESCRIPTION
## Summary
- implement `gradeFreeResponse` that calls DeepSeek three times and uses majority vote
- add unit tests for the ensemble grader
- extract grader system prompt into its own file

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684082cc46b4833090eb277a5daa2074