### PR TITLE
Implement item generator prompt

### DIFF
--- a/server/__tests__/itemGenerator.test.ts
+++ b/server/__tests__/itemGenerator.test.ts
@@ -1,0 +1,62 @@
+import { generateItem, generateTieredItems } from '../src/llm/itemGenerator';
+import { deepSeekChat } from '../src/llm/deepseek';
+
+jest.mock('../src/llm/deepseek', () => ({
+  deepSeekChat: jest.fn()
+}));
+
+const mockChat = deepSeekChat as jest.Mock;
+
+beforeEach(() => {
+  mockChat.mockReset();
+});
+
+test('generateItem parses LLM response', async () => {
+  mockChat.mockResolvedValue({
+    choices: [
+      { message: { content: '{"stem":"Q1","reference":"A1","bloom":"Remember","tier":1,"explanation":"E1"}' } }
+    ]
+  });
+
+  const item = await generateItem({
+    objective: 'Define X',
+    bloom: 'Remember',
+    tier: 1,
+    context: 'text',
+    previous: []
+  });
+
+  expect(item.stem).toBe('Q1');
+  expect(mockChat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      messages: [
+        { role: 'system', content: expect.any(String) },
+        { role: 'user', content: expect.stringContaining('Objective: Define X') }
+      ]
+    })
+  );
+});
+
+test('generateTieredItems requests three tiers', async () => {
+  mockChat
+    .mockResolvedValueOnce({
+      choices: [
+        { message: { content: '{"stem":"Q1","reference":"A1","bloom":"Remember","tier":1,"explanation":"E1"}' } }
+      ]
+    })
+    .mockResolvedValueOnce({
+      choices: [
+        { message: { content: '{"stem":"Q3","reference":"A3","bloom":"Apply","tier":3,"explanation":"E3"}' } }
+      ]
+    })
+    .mockResolvedValueOnce({
+      choices: [
+        { message: { content: '{"stem":"Q5","reference":"A5","bloom":"Evaluate","tier":5,"explanation":"E5"}' } }
+      ]
+    });
+
+  const items = await generateTieredItems('Sample', 'ctx', ['Remember', 'Apply', 'Evaluate']);
+  expect(items).toHaveLength(3);
+  expect(items.map((i) => i.tier)).toEqual([1, 3, 5]);
+  expect(mockChat).toHaveBeenCalledTimes(3);
+});

--- a/server/src/llm/itemGenerator.ts
+++ b/server/src/llm/itemGenerator.ts
@@ -1,0 +1,79 @@
+import { deepSeekChat } from './deepseek';
+import { itemGeneratorSystem, itemGeneratorUser } from './prompts/itemGenerator';
+
+export interface GeneratedItem {
+  stem: string;
+  reference: string;
+  bloom: string;
+  tier: number;
+  explanation: string;
+}
+
+// Generates a single practice item for Scheduler given Bloom level and tier.
+export async function generateItem(params: {
+  objective: string;
+  bloom: string;
+  tier: number;
+  context: string;
+  previous: string[];
+}): Promise<GeneratedItem> {
+  const body = {
+    model: 'deepseek-chat',
+    messages: [
+      { role: 'system', content: itemGeneratorSystem },
+      {
+        role: 'user',
+        content: itemGeneratorUser(
+          params.objective,
+          params.bloom,
+          params.tier,
+          params.context,
+          params.previous
+        )
+      }
+    ],
+    temperature: 0.7
+  };
+
+  const res = await deepSeekChat(body);
+  const text = res.choices?.[0]?.message?.content ?? '{}';
+  let obj: unknown;
+  try {
+    obj = JSON.parse(text);
+  } catch {
+    throw new Error('invalid_response');
+  }
+  if (!obj || typeof obj !== 'object') {
+    throw new Error('invalid_response');
+  }
+  const o = obj as Record<string, unknown>;
+  return {
+    stem: String(o.stem || ''),
+    reference: String(o.reference || ''),
+    bloom: String(o.bloom || ''),
+    tier: Number(o.tier || 0),
+    explanation: String(o.explanation || '')
+  };
+}
+
+export async function generateTieredItems(
+  objective: string,
+  context: string,
+  blooms: string[]
+): Promise<GeneratedItem[]> {
+  const tiers = [1, 3, 5];
+  const prior: string[] = [];
+  const items: GeneratedItem[] = [];
+  for (let i = 0; i < tiers.length; i++) {
+    const item = await generateItem({
+      objective,
+      bloom: blooms[i] || blooms[0],
+      tier: tiers[i],
+      context,
+      previous: prior
+    });
+    prior.push(item.stem);
+    items.push(item);
+  }
+  return items;
+}

--- a/server/src/llm/prompts/itemGenerator.ts
+++ b/server/src/llm/prompts/itemGenerator.ts
@@ -1,0 +1,34 @@
+export const itemGeneratorSystem = `You are an assessment-item generator.
+Return a **single JSON object** with these keys:
+  "stem"        : string   # ≤ 30 words, no numbering
+  "reference"   : string   # canonical answer or rubric bullets
+  "bloom"       : string   # Bloom level used
+  "tier"        : integer  # 1 = easy, 3 = core, 5 = stretch
+  "explanation" : string   # ≤ 40 words, model answer rationale
+
+Constraints:
+- Free-response only (NO multiple-choice options).
+- Do NOT reveal the rubric in the stem.
+- Avoid duplicating any prior stems supplied.
+- Use notation consistent with the context.
+- JSON only, no markdown fences.`;
+
+export const itemGeneratorUser = (
+  objective: string,
+  bloom: string,
+  tier: number,
+  context: string,
+  prior: string[]
+) => `Objective: ${objective}
+Requested Bloom level: ${bloom}
+Difficulty tier: ${tier}
+
+Chapter context (≤ 400 tokens, for jargon alignment):
+"""
+${context}
+"""
+
+Previously served stems to this learner:
+${prior.join('\n')}
+
+Generate the assessment item now.`;


### PR DESCRIPTION
## Summary
- add item generator prompt templates
- implement item generator helpers
- test tiered item generation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6840ecf8c40c8330b907d3416f0f983e