### PR TITLE
Improve test coverage with additional edge cases

### DIFF
--- a/server/__tests__/admin.test.ts
+++ b/server/__tests__/admin.test.ts
@@ -37,3 +37,29 @@ test('DELETE /api/objectives/:id returns 204', async () => {
   const res = await request(app).delete('/api/objectives/1');
   expect(res.status).toBe(204);
 });
+
+
+test('PUT /api/objectives/:id handles missing objective', async () => {
+  (db.objective.update as jest.Mock).mockRejectedValue(new Error('not found'));
+  const res = await request(app).put('/api/objectives/1').send({ text: 'x' });
+  expect(res.status).toBe(404);
+});
+
+test('GET /api/items returns list', async () => {
+  (db.item.findMany as jest.Mock).mockResolvedValue([{ id: 1 }]);
+  const res = await request(app).get('/api/items');
+  expect(res.status).toBe(200);
+  expect(res.body.items).toHaveLength(1);
+});
+
+test('DELETE /api/items/:id handles missing item', async () => {
+  (db.item.delete as jest.Mock).mockRejectedValue(new Error('nope'));
+  const res = await request(app).delete('/api/items/1');
+  expect(res.status).toBe(404);
+});
+
+test('DELETE /api/items/:id returns 204', async () => {
+  (db.item.delete as jest.Mock).mockResolvedValue({});
+  const res = await request(app).delete('/api/items/2');
+  expect(res.status).toBe(204);
+});

--- a/server/__tests__/chunker.test.ts
+++ b/server/__tests__/chunker.test.ts
@@ -5,3 +5,12 @@ test('splits text into fixed-size chunks', () => {
   expect(chunks).toEqual(['a'.repeat(10), 'a'.repeat(10), 'a'.repeat(5)]);
 });
 
+
+test('returns empty array for empty text', () => {
+  expect(splitIntoChunks('', 5)).toEqual([]);
+});
+
+test('uses default size when not provided', () => {
+  const sample = 'abc';
+  expect(splitIntoChunks(sample)).toEqual([sample]);
+});

--- a/server/__tests__/deepseek.test.ts
+++ b/server/__tests__/deepseek.test.ts
@@ -11,3 +11,14 @@ test('deepseek wrapper retries', async () => {
   const res = await deepSeekChat({ messages: [] });
   expect(res.id).toBe(1);
 });
+
+test('deepseek wrapper throws after retries', async () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  nock('https://api.deepseek.com')
+    .post('/v1/chat/completions')
+    .times(2)
+    .reply(500, { err: 'bad' });
+  await expect(deepSeekChat({ messages: [] })).rejects.toThrow();
+  expect(spy).toHaveBeenCalled();
+  spy.mockRestore();
+});

--- a/server/__tests__/extract.test.ts
+++ b/server/__tests__/extract.test.ts
@@ -34,3 +34,28 @@ test('objective extractor returns objects', async () => {
   expect(res.body.objectives[0].id).toBe('A-1');
 });
 
+
+test('extract requires text', async () => {
+  const res = await request(app)
+    .post('/api/objectives/extract')
+    .send({ course: 'Demo' });
+  expect(res.status).toBe(400);
+});
+
+test('extract requires course', async () => {
+  const res = await request(app)
+    .post('/api/objectives/extract')
+    .send({ text: 'hi' });
+  expect(res.status).toBe(400);
+});
+
+test('LLM failure returns 500', async () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  nock('https://api.deepseek.com').post('/v1/chat/completions').reply(500);
+  const res = await request(app)
+    .post('/api/objectives/extract')
+    .send({ course: 'Demo', text: 'x' });
+  expect(res.status).toBe(500);
+  expect(spy).toHaveBeenCalled();
+  spy.mockRestore();
+});

--- a/server/__tests__/grader.test.ts
+++ b/server/__tests__/grader.test.ts
@@ -57,3 +57,10 @@ test('all different verdicts escalate', async () => {
   expect(res.verdict).toBe('escalate');
   expect(res.score).toBeNull();
 });
+
+test('invalid JSON defaults to incorrect', async () => {
+  mockChat.mockResolvedValue({ choices: [{ message: { content: 'oops' } }] });
+  const res = await gradeFreeResponse('Q', 'A');
+  expect(res.verdict).toBe('incorrect');
+  expect(res.score).toBe(0);
+});

--- a/server/__tests__/itemGenerator.test.ts
+++ b/server/__tests__/itemGenerator.test.ts
@@ -60,3 +60,17 @@ test('generateTieredItems requests three tiers', async () => {
   expect(items.map((i) => i.tier)).toEqual([1, 3, 5]);
   expect(mockChat).toHaveBeenCalledTimes(3);
 });
+
+test('generateItem rejects on invalid JSON', async () => {
+  mockChat.mockResolvedValue({ choices: [{ message: { content: 'bad' } }] });
+  await expect(
+    generateItem({ objective: 'o', bloom: 'b', tier: 1, context: 'c', previous: [] })
+  ).rejects.toThrow('invalid_response');
+});
+
+test('generateItem rejects when not object', async () => {
+  mockChat.mockResolvedValue({ choices: [{ message: { content: '5' } }] });
+  await expect(
+    generateItem({ objective: 'o', bloom: 'b', tier: 1, context: 'c', previous: [] })
+  ).rejects.toThrow('invalid_response');
+});

--- a/server/__tests__/objectivePrompt.errors.test.ts
+++ b/server/__tests__/objectivePrompt.errors.test.ts
@@ -1,0 +1,27 @@
+import { extractObjectives } from '../src/objectives';
+import { deepSeekChat } from '../src/llm/deepseek';
+
+jest.mock('../src/llm/deepseek', () => ({
+  deepSeekChat: jest.fn()
+}));
+
+const mockChat = deepSeekChat as jest.Mock;
+
+beforeEach(() => {
+  mockChat.mockReset();
+});
+
+test('invalid JSON throws', async () => {
+  mockChat.mockResolvedValue({ choices: [{ message: { content: 'not-json' } }] });
+  await expect(extractObjectives('Course', 'text')).rejects.toThrow('invalid JSON');
+});
+
+test('non-array response throws', async () => {
+  mockChat.mockResolvedValue({ choices: [{ message: { content: '{}' } }] });
+  await expect(extractObjectives('C', 't')).rejects.toThrow('invalid response');
+});
+
+test('invalid objective throws', async () => {
+  mockChat.mockResolvedValue({ choices: [{ message: { content: '[{"id":1}]' } }] });
+  await expect(extractObjectives('C', 't')).rejects.toThrow('invalid objective');
+});

--- a/server/__tests__/upload.test.ts
+++ b/server/__tests__/upload.test.ts
@@ -19,3 +19,8 @@ test('upload route saves text', async () => {
   const saved = await fs.readFile(path.join(UPLOAD_DIR, `${id}.txt`), 'utf8');
   expect(saved).toBe(sample);
 });
+
+test('upload route validates text', async () => {
+  const res = await request(app).post('/api/upload').send({});
+  expect(res.status).toBe(400);
+});

--- a/shared/__tests__/db.extra.test.ts
+++ b/shared/__tests__/db.extra.test.ts
@@ -1,0 +1,55 @@
+import { db, user, item, review, itemState, objectiveState, clusterState, objective } from '../db';
+import { execSync } from 'child_process';
+
+beforeAll(() => {
+  execSync('pnpm --filter server exec prisma db push --skip-generate', { stdio: 'inherit' });
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+});
+
+test('exercise all db helpers', async () => {
+  const u = await user.create({ data: { uuid: 'u1' } });
+  await user.update({ where: { id: u.id }, data: { uuid: 'u2' } });
+  const uFound = await user.find({ id: u.id });
+  expect(uFound?.uuid).toBe('u2');
+
+  const obj = await objective.create({ data: { clusterId: 1, text: 't', bloom: 'Remember' } });
+  await objective.update({ where: { id: obj.id }, data: { text: 't2' } });
+  const objFound = await objective.find({ id: obj.id });
+  expect(objFound?.text).toBe('t2');
+
+  const itm = await item.create({ data: { objectiveId: obj.id, tier: 1, stem: 's', reference: 'r' } });
+  await item.update({ where: { id: itm.id }, data: { tier: 2 } });
+  const itmFound = await item.find({ id: itm.id });
+  expect(itmFound?.tier).toBe(2);
+
+  const rev = await review.create({ data: { userId: u.id, itemId: itm.id, verdict: 'correct', score: 1 } });
+  await review.update({ where: { id: rev.id }, data: { score: 0.5 } });
+  const revFound = await review.find({ id: rev.id });
+  expect(revFound?.score).toBe(0.5);
+
+  const is = await itemState.create({ data: { userId: u.id, itemId: itm.id, stability: 1, difficulty: 1, ease: 1, nextDue: new Date(), p_recall: 0.5 } });
+  await itemState.update({ where: { id: is.id }, data: { p_recall: 0.8 } });
+  const isFound = await itemState.find({ id: is.id });
+  expect(isFound?.p_recall).toBe(0.8);
+
+  const os = await objectiveState.create({ data: { userId: u.id, objectiveId: obj.id, p_mastery: 0.1 } });
+  await objectiveState.update({ where: { id: os.id }, data: { p_mastery: 0.2 } });
+  const osFound = await objectiveState.find({ id: os.id });
+  expect(osFound?.p_mastery).toBe(0.2);
+
+  const cs = await clusterState.create({ data: { userId: u.id, clusterId: 1 } });
+  await clusterState.update({ where: { id: cs.id }, data: { unlocked: true } });
+  const csFound = await clusterState.find({ id: cs.id });
+  expect(csFound?.unlocked).toBe(true);
+
+  await clusterState.remove({ id: cs.id });
+  await objectiveState.remove({ id: os.id });
+  await itemState.remove({ id: is.id });
+  await review.remove({ id: rev.id });
+  await item.remove({ id: itm.id });
+  await objective.remove({ id: obj.id });
+  await user.remove({ id: u.id });
+});


### PR DESCRIPTION
## Summary
- cover more failure branches in admin, deepseek, grader and item generation logic
- add coverage for chunker edge cases and upload validation
- test objective extraction errors and database helper functions

## Testing
- `pnpm lint`
- `pnpm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6840f13eba2c8330ac039c367bf88745