### PR TITLE
Implement practice view

### DIFF
--- a/client/__tests__/practiceView.test.tsx
+++ b/client/__tests__/practiceView.test.tsx
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { PracticeView } from '../src/PracticeView';
+import * as api from '../src/api';
+
+jest.mock('../src/api');
+const mockNext = api.fetchNextItem as jest.Mock;
+const mockSubmit = api.submitAnswer as jest.Mock;
+
+beforeEach(() => {
+  mockNext.mockResolvedValue({ id: 1, stem: 'Q1' });
+  mockSubmit.mockResolvedValue({ verdict: 'correct', feedback: 'good' });
+});
+
+test('loads and submits item', async () => {
+  const { getByText, getByRole } = render(<PracticeView />);
+  await waitFor(() => getByText('Q1'));
+
+  fireEvent.change(getByRole('textbox'), { target: { value: 'A' } });
+  fireEvent.click(getByText('Submit'));
+
+  await waitFor(() => expect(mockSubmit).toHaveBeenCalledWith(1, 'A'));
+  await waitFor(() => expect(mockNext).toHaveBeenCalledTimes(2));
+  await waitFor(() => getByRole('alert'));
+});

--- a/client/src/PracticeView.tsx
+++ b/client/src/PracticeView.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { fetchNextItem, submitAnswer } from './api';
+
+interface Item {
+  id: number;
+  stem: string;
+}
+
+export function PracticeView() {
+  const [item, setItem] = useState<Item | null>(null);
+  const [answer, setAnswer] = useState('');
+  const [toast, setToast] = useState('');
+
+  const loadItem = async () => {
+    const res = await fetchNextItem();
+    setItem(res);
+    setAnswer('');
+  };
+
+  useEffect(() => {
+    loadItem();
+  }, []);
+
+  const handleSubmit = async () => {
+    if (!item) return;
+    const res = await submitAnswer(item.id, answer);
+    setToast(res.verdict + (res.feedback ? `: ${res.feedback}` : ''));
+    setTimeout(() => setToast(''), 2000);
+    await loadItem();
+  };
+
+  if (!item) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>{item.stem}</h2>
+      <textarea
+        value={answer}
+        onChange={(e) => setAnswer(e.target.value)}
+      />
+      <button onClick={handleSubmit}>Submit</button>
+      {toast && <div role="alert">{toast}</div>}
+    </div>
+  );
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -11,3 +11,17 @@ export async function apiFetch(
   };
   return fetch(input, { ...init, headers });
 }
+
+export async function fetchNextItem() {
+  const res = await apiFetch('/api/session/next');
+  return res.json();
+}
+
+export async function submitAnswer(itemId: number, answer: string) {
+  const res = await apiFetch(`/api/session/${itemId}/answer`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ answer }),
+  });
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add PracticeView component to handle practice session flow
- extend api helpers with fetchNextItem and submitAnswer
- add tests for practice view

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68410baaf0208330ba51c48f6141afda