### PR TITLE
Add manual text option to upload wizard

### DIFF
--- a/client/__tests__/uploadWizard.test.tsx
+++ b/client/__tests__/uploadWizard.test.tsx
@@ -8,6 +8,7 @@ jest.mock('../src/api');
 const mockFetch = api.apiFetch as jest.Mock;
 
 beforeEach(() => {
+  mockFetch.mockClear();
   mockFetch.mockResolvedValue({ json: async () => ({ upload_id: 'u1' }) });
 });
 
@@ -18,6 +19,16 @@ test('step flow', async () => {
   Object.defineProperty(file, 'text', { value: () => Promise.resolve('hello') });
   Object.defineProperty(fileInput, 'files', { value: [file] });
   fireEvent.change(fileInput);
+  await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+  await waitFor(() => getByText('Edit Objectives'));
+});
+
+test('typed text flow', async () => {
+  const { getByPlaceholderText, getByText } = render(<UploadWizard />);
+  fireEvent.change(getByPlaceholderText('Paste text here'), {
+    target: { value: 'hello' },
+  });
+  fireEvent.click(getByText('Use Text'));
   await waitFor(() => expect(mockFetch).toHaveBeenCalled());
   await waitFor(() => getByText('Edit Objectives'));
 });

--- a/client/src/UploadWizard.tsx
+++ b/client/src/UploadWizard.tsx
@@ -3,8 +3,10 @@ import { apiFetch } from './api';
 
 export function UploadWizard() {
   const [step, setStep] = useState(1);
-interface Extracted { text: string }
+  interface Extracted { text: string }
+
   const [fileText, setFileText] = useState('');
+  const [typedText, setTypedText] = useState('');
   const [title, setTitle] = useState('');
   const [objectives, setObjectives] = useState<string[]>([]);
   const [uploadId, setUploadId] = useState('');
@@ -18,6 +20,19 @@ interface Extracted { text: string }
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text }),
+    });
+    const data = await res.json();
+    setUploadId(data.upload_id);
+    setStep(2);
+  };
+
+  const handleText = async () => {
+    if (!typedText.trim()) return;
+    setFileText(typedText);
+    const res = await apiFetch('/api/upload', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: typedText }),
     });
     const data = await res.json();
     setUploadId(data.upload_id);
@@ -42,6 +57,7 @@ interface Extracted { text: string }
     });
     setStep(1);
     setFileText('');
+    setTypedText('');
     setObjectives([]);
     setTitle('');
     alert('Saved');
@@ -50,8 +66,14 @@ interface Extracted { text: string }
   if (step === 1) {
     return (
       <div key="upload">
-        <h2>Upload File</h2>
+        <h2>Upload File or Paste Text</h2>
         <input type="file" onChange={handleFile} />
+        <textarea
+          placeholder="Paste text here"
+          value={typedText}
+          onChange={(e) => setTypedText(e.target.value)}
+        />
+        <button onClick={handleText}>Use Text</button>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- allow typing text directly in UploadWizard
- reset typed text after saving
- test manual text flow

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684117e904e08330bea7f1dbd21d0aa2