### PR TITLE
Configure Vite proxy for API calls

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add client/vite.config.ts to proxy `/api` to the Express server

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6841f03b47008330af42d92831e6a2b6