### PR TITLE
Auto seed on dev start

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ pnpm install
 
 ## Development
 
-- **Start servers** – `pnpm dev` (runs client and server concurrently).
+- **Start servers** – `pnpm dev` (seeds the database then runs client and server concurrently).
 - **Lint** – `pnpm lint`
 - **Test** – `pnpm test`
-- **Seed database** – `pnpm seed`
+- **Seed database manually** – `pnpm seed`
 
-Always run lint and tests before committing. The seed command pushes the Prisma
-schema and populates demo data in `server/prisma/seed.ts`.
+`pnpm dev` automatically pushes the Prisma schema and seeds demo data before starting the servers. Always run lint and tests before committing.
 
 ## Architecture Overview
 
@@ -66,7 +65,7 @@ An example environment file lives at `.env.example` and includes a
 ## Running in Development
 
 ```bash
-pnpm dev      # start client and server
+pnpm dev      # seed then start client and server
 pnpm lint     # run ESLint
 pnpm test     # execute unit tests
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "shared"
   ],
   "scripts": {
-    "dev": "concurrently -n client,server -c green,cyan \"pnpm --filter client dev\" \"pnpm --filter server dev\"",
+    "dev": "pnpm seed && concurrently -n client,server -c green,cyan \"pnpm --filter client dev\" \"pnpm --filter server dev\"",
     "lint": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
     "test": "jest",
     "coverage": "jest --coverage && node scripts/makeBadge.js",


### PR DESCRIPTION
## Summary
- run `pnpm seed` automatically before spinning up client and server
- document automatic seeding in the README

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm seed`


------
https://chatgpt.com/codex/tasks/task_e_6841f62ad19483309a3d291289399a6f