### PR TITLE
Handle objective extract errors

### DIFF
--- a/client/__tests__/uploadWizard.test.tsx
+++ b/client/__tests__/uploadWizard.test.tsx
@@ -32,3 +32,21 @@ test('typed text flow', async () => {
   await waitFor(() => expect(mockFetch).toHaveBeenCalled());
   await waitFor(() => getByText('Edit Objectives'));
 });
+
+test('alert on extraction failure', async () => {
+  mockFetch.mockClear();
+  mockFetch
+    .mockResolvedValueOnce({ json: async () => ({ upload_id: 'u1' }) })
+    .mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'bad' }) });
+  const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+  const { getByPlaceholderText, getByText } = render(<UploadWizard />);
+  fireEvent.change(getByPlaceholderText('Paste text here'), {
+    target: { value: 'hello' },
+  });
+  fireEvent.click(getByText('Use Text'));
+  await waitFor(() => getByText('Edit Objectives'));
+
+  fireEvent.click(getByText('Load'));
+  await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('Failed to load objectives'));
+});

--- a/client/src/UploadWizard.tsx
+++ b/client/src/UploadWizard.tsx
@@ -40,13 +40,21 @@ export function UploadWizard() {
   };
 
   const extractObjectives = async () => {
-    const res = await apiFetch('/api/objectives/extract', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ course: title, text: fileText }),
-    });
-    const data = await res.json();
-    setObjectives(data.objectives.map((o: Extracted) => o.text));
+    try {
+      const res = await apiFetch('/api/objectives/extract', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ course: title, text: fileText }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? 'server_error');
+      }
+      const data = await res.json();
+      setObjectives(data.objectives.map((o: Extracted) => o.text));
+    } catch {
+      alert('Failed to load objectives');
+    }
   };
 
   const saveCourse = async () => {


### PR DESCRIPTION
## Summary
- add error handling when extracting objectives
- test failed objective extraction
- remove unused variable in catch block

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6842466888fc8330bbbcd10f3920cb42