### PR TITLE
Improve objective entry UX

### DIFF
--- a/client/src/ObjectivesPage.tsx
+++ b/client/src/ObjectivesPage.tsx
@@ -9,6 +9,13 @@ export function ObjectivesPage() {
   const [objectives, setObjectives] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void extract();
+    }
+  };
+
   const extract = async () => {
     if (!text.trim() || !course.trim()) return;
     setLoading(true);
@@ -35,20 +42,20 @@ export function ObjectivesPage() {
         placeholder="Course Title"
         value={course}
         onChange={(e) => setCourse(e.target.value)}
+        onKeyDown={handleKeyDown}
       />
       <textarea
         placeholder="Paste text here"
         value={text}
         onChange={(e) => setText(e.target.value)}
+        onKeyDown={handleKeyDown}
       />
       <button onClick={extract} disabled={loading}>
         {loading ? 'Loading...' : 'Extract'}
       </button>
-      <ul>
-        {objectives.map((o, i) => (
-          <li key={i}>{o}</li>
-        ))}
-      </ul>
+      {!!objectives.length && (
+        <textarea readOnly value={objectives.join('\n')} />
+      )}
     </div>
   );
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { initAnonUser } from './auth';
 import { ObjectivesPage } from './ObjectivesPage';
+import './style.css';
 
 initAnonUser();
 

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1,0 +1,28 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+}
+
+input, textarea, button {
+  font-size: 1rem;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+input, textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+textarea {
+  height: 150px;
+}
+
+button {
+  cursor: pointer;
+}
+
+ul {
+  margin-top: 1rem;
+  padding-left: 1.2rem;
+}


### PR DESCRIPTION
## Summary
- make entry page less ugly: larger inputs and CSS
- handle Enter key to submit text
- show extracted objectives in a textarea

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68432746501c8330a222f58e8a119b00