### PR TITLE
Add console logging for objective flow

### DIFF
--- a/client/src/ObjectivesPage.tsx
+++ b/client/src/ObjectivesPage.tsx
@@ -18,6 +18,7 @@ export function ObjectivesPage() {
 
   const extract = async () => {
     if (!text.trim() || !course.trim()) return;
+    console.log('Sending objective extraction request');
     setLoading(true);
     try {
       const res = await apiFetch('/api/objectives/extract', {
@@ -27,11 +28,14 @@ export function ObjectivesPage() {
       });
       if (!res.ok) throw new Error('server_error');
       const data = await res.json();
+      console.log('Objectives received:', data.objectives);
       setObjectives(data.objectives.map((o: Extracted) => o.text));
-    } catch {
+    } catch (err) {
+      console.error('Failed to load objectives', err);
       alert('Failed to load objectives');
     } finally {
       setLoading(false);
+      console.log('Request complete');
     }
   };
 
@@ -53,9 +57,11 @@ export function ObjectivesPage() {
       <button onClick={extract} disabled={loading}>
         {loading ? 'Loading...' : 'Extract'}
       </button>
-      {!!objectives.length && (
-        <textarea readOnly value={objectives.join('\n')} />
-      )}
+      <textarea
+        readOnly
+        placeholder="Objectives will appear here"
+        value={objectives.join('\n')}
+      />
     </div>
   );
 }

--- a/client/src/UploadWizard.tsx
+++ b/client/src/UploadWizard.tsx
@@ -14,6 +14,7 @@ export function UploadWizard() {
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    console.log('Reading file:', file.name);
     const text = await file.text();
     setFileText(text);
     const res = await apiFetch('/api/upload', {
@@ -22,6 +23,7 @@ export function UploadWizard() {
       body: JSON.stringify({ text }),
     });
     const data = await res.json();
+    console.log('Upload ID received:', data.upload_id);
     setUploadId(data.upload_id);
     setStep(2);
   };
@@ -29,18 +31,21 @@ export function UploadWizard() {
   const handleText = async () => {
     if (!typedText.trim()) return;
     setFileText(typedText);
+    console.log('Uploading typed text');
     const res = await apiFetch('/api/upload', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text: typedText }),
     });
     const data = await res.json();
+    console.log('Upload ID received:', data.upload_id);
     setUploadId(data.upload_id);
     setStep(2);
   };
 
   const extractObjectives = async () => {
     try {
+      console.log('Requesting objectives for', title);
       const res = await apiFetch('/api/objectives/extract', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -51,18 +56,22 @@ export function UploadWizard() {
         throw new Error(err.error ?? 'server_error');
       }
       const data = await res.json();
+      console.log('Objectives received:', data.objectives);
       setObjectives(data.objectives.map((o: Extracted) => o.text));
-    } catch {
+    } catch (err) {
+      console.error('Failed to load objectives', err);
       alert('Failed to load objectives');
     }
   };
 
   const saveCourse = async () => {
+    console.log('Saving course');
     await apiFetch('/api/courses', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ title, uploadId }),
     });
+    console.log('Course saved');
     setStep(1);
     setFileText('');
     setTypedText('');

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,7 +32,9 @@ app.post('/api/objectives/extract', async (req, res) => {
     return res.status(400).json({ error: 'course required' });
   }
   try {
+    console.log('Extracting objectives for', course);
     const objectives = await extractObjectives(course, text);
+    console.log('Objectives extracted:', objectives.length);
     res.json({ objectives });
   } catch (err) {
     console.error(err);

--- a/server/src/objectives.ts
+++ b/server/src/objectives.ts
@@ -50,6 +50,7 @@ export async function extractObjectives(
   course: string,
   text: string
 ): Promise<ExtractedObjective[]> {
+  console.log('Calling LLM for course', course);
   const body = {
     model: 'deepseek-chat',
     messages: [
@@ -60,7 +61,10 @@ export async function extractObjectives(
   };
 
   const res = await deepSeekChat(body);
+  console.log('LLM response received');
   const content = res.choices?.[0]?.message?.content ?? '[]';
-  return parseList(content);
+  const parsed = parseList(content);
+  console.log('Parsed', parsed.length, 'objectives');
+  return parsed;
 }
 


### PR DESCRIPTION
## Summary
- log progress in `ObjectivesPage` and always show textarea
- add logging for upload wizard actions
- print progress when extracting objectives server-side

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68432999c67c83309575e9a50a6a750f