### PR TITLE
Extend DeepSeek timeout

### DIFF
--- a/server/src/llm/deepseek.ts
+++ b/server/src/llm/deepseek.ts
@@ -10,7 +10,7 @@ const ds = axios.create({
     'Content-Type': 'application/json'
   },
   proxy: false,
-  timeout: 15000
+  timeout: 60000
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
- extend HTTP timeout in DeepSeek client from 15s to 60s

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68432f3043d883308127761e102b50ae