### PR TITLE
feat: restyle objectives page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It contains a React client, an Express API, and shared TypeScript utilities.
 
 Node 20 and pnpm 9 are required. Install dependencies at the repo root:
 
+Run `pnpm install` once after cloning to install workspace dependencies:
+
 ```bash
 pnpm install
 ```

--- a/client/src/ObjectivesPage.tsx
+++ b/client/src/ObjectivesPage.tsx
@@ -40,35 +40,43 @@ export function ObjectivesPage() {
   };
 
   return (
-    <div className="max-w-xl mx-auto p-6 bg-white rounded-lg shadow space-y-4">
-      <h2 className="text-xl font-semibold">Objective Extractor</h2>
-      <input
-        className="w-full border rounded p-2"
-        placeholder="Course Title"
-        value={course}
-        onChange={(e) => setCourse(e.target.value)}
-        onKeyDown={handleKeyDown}
-      />
-      <textarea
-        className="w-full border rounded p-2 h-40"
-        placeholder="Paste text here"
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        onKeyDown={handleKeyDown}
-      />
-      <button
-        className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
-        onClick={extract}
-        disabled={loading}
-      >
-        {loading ? 'Loading...' : 'Extract'}
-      </button>
-      <textarea
-        className="w-full border rounded p-2 h-40"
-        readOnly
-        placeholder="Objectives will appear here"
-        value={objectives.join('\n')}
-      />
+    <div className="max-w-xl mx-auto p-4 space-y-4">
+      <header className="bg-gradient-to-r from-indigo-500 to-purple-500 text-white p-4 rounded-2xl shadow-sm">
+        <h2 className="text-xl font-semibold">Objective Extractor</h2>
+      </header>
+      <div className="bg-white rounded-2xl shadow p-4 space-y-4">
+        <input
+          className="w-full border border-gray-300 rounded-xl p-2 focus:ring"
+          placeholder="Course Title"
+          value={course}
+          onChange={(e) => setCourse(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <textarea
+          className="w-full border border-gray-300 rounded-xl p-2 h-40 focus:ring"
+          placeholder="Paste text here"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          className="bg-indigo-500 hover:bg-purple-500 text-white px-4 py-2 rounded-xl disabled:opacity-50"
+          onClick={extract}
+          disabled={loading}
+        >
+          {loading ? 'Loading...' : 'Extract'}
+        </button>
+        <div className="space-y-2">
+          {objectives.map((obj, i) => (
+            <div
+              key={i}
+              className="prose text-gray-700 shadow-sm rounded-2xl p-3"
+            >
+              {obj}
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,7 +1,14 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        accent: '#6366F1',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   ],
   "scripts": {
     "dev": "pnpm seed && concurrently -n client,server -c green,cyan \"pnpm --filter client dev\" \"pnpm --filter server dev\"",
-    "lint": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
-    "test": "jest",
-    "coverage": "jest --coverage && node scripts/makeBadge.js",
+    "lint": "pnpm exec eslint \"**/*.{ts,tsx}\" --max-warnings=0",
+    "test": "pnpm exec jest",
+    "coverage": "pnpm exec jest --coverage && node scripts/makeBadge.js",
     "dev:test": "pnpm exec start-server-and-test 'pnpm dev' 'http://localhost:5173|http://localhost:3000/health' 'echo done'",
     "seed": "pnpm --filter server exec prisma db push && pnpm exec tsx server/prisma/seed.ts"
   },


### PR DESCRIPTION
## Summary
- enhance Objectives page UI with gradient header and chat bubbles
- add custom accent color and font to Tailwind config
- ensure local binaries are used for lint and test

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68435464a3d88330beadd38337201915