### PR TITLE
Add dependency graph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ shared package.
 
 - **Text Upload** – `POST /api/upload` saves raw text and returns an `upload_id`.
 - **Objective Extraction** – `POST /api/objectives/extract` sends text to the
-  DeepSeek LLM and returns a JSON list of objectives.
+  DeepSeek LLM and returns a JSON list of objectives along with a cluster
+  dependency graph.
 - **Course Creation** – `POST /api/courses` associates a title with an uploaded
   text file.
 - **Admin CRUD** – `/api/objectives` and `/api/items` expose basic management

--- a/server/__tests__/extract.test.ts
+++ b/server/__tests__/extract.test.ts
@@ -12,7 +12,8 @@ beforeEach(() => {
 
 test('objective extractor returns objects', async () => {
   const text = await fs.readFile(samplePath, 'utf8');
-  nock('https://api.deepseek.com')
+  const llm = nock('https://api.deepseek.com');
+  llm
     .post('/v1/chat/completions')
     .reply(200, {
       choices: [
@@ -24,6 +25,10 @@ test('objective extractor returns objects', async () => {
           }
         }
       ]
+    })
+    .post('/v1/chat/completions')
+    .reply(200, {
+      choices: [{ message: { content: '{"Intro":[]}' } }]
     });
 
   const res = await request(app)
@@ -32,6 +37,7 @@ test('objective extractor returns objects', async () => {
 
   expect(res.status).toBe(200);
   expect(res.body.objectives[0].id).toBe('A-1');
+  expect(res.body.graph).toEqual({ Intro: [] });
 });
 
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,7 +36,8 @@ app.post('/api/objectives/extract', async (req, res) => {
     console.log('Extracting objectives for', course);
     const objectives = await extractObjectives(course, text);
     console.log('Objectives extracted:', objectives.length);
-    res.json({ objectives });
+    const graph = await generateClusterGraph(objectives);
+    res.json({ objectives, graph });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'llm_error' });


### PR DESCRIPTION
## Summary
- return cluster graph in `POST /api/objectives/extract`
- update extract endpoint test for new graph
- document new behaviour in README

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a6fabc8c8330b4c4292c37e8f508