### PR TITLE
Fix lint in ObjectivesPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ shared package.
 
 - **Text Upload** – `POST /api/upload` saves raw text and returns an `upload_id`.
 - **Objective Extraction** – `POST /api/objectives/extract` sends text to the
-  DeepSeek LLM and returns a JSON list of objectives.
+  DeepSeek LLM and returns a JSON list of objectives along with a cluster
+  dependency graph.
 - **Course Creation** – `POST /api/courses` associates a title with an uploaded
   text file.
 - **Admin CRUD** – `/api/objectives` and `/api/items` expose basic management
@@ -95,6 +96,9 @@ shared package.
   and course save.
 - **Practice View** – Simple learner interface that submits free responses and
   loads the next item.
+- **Dependency Graph** – `POST /api/graph/generate` builds a cluster graph from
+  a list of objectives. All objective fields (`id`, `text`, `bloom`, `cluster`)
+  must be non-empty strings.
 ---
 
 Contributions should follow the coding guidelines in `AGENT.md`, keeping

--- a/client/src/ObjectivesPage.tsx
+++ b/client/src/ObjectivesPage.tsx
@@ -2,10 +2,17 @@ import React, { useState } from 'react';
 import { apiFetch } from './api';
 import './chatgpt-theme.css';
 
-interface ExtractedObjective { 
+interface ExtractedObjective {
   id: string;
   text: string;
   cluster: string;
+}
+
+// Shape returned from the API. Fields may be missing so they are optional.
+interface ApiObjective {
+  id?: string;
+  text: string;
+  cluster?: string;
 }
 
 // Generate a unique ID for objectives
@@ -15,6 +22,7 @@ export function ObjectivesPage() {
   const [text, setText] = useState('');
   const [course, setCourse] = useState('');
   const [objectives, setObjectives] = useState<ExtractedObjective[]>([]);
+  const [graph, setGraph] = useState<Record<string, string[]>>({});
   const [loading, setLoading] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [editedObjectives, setEditedObjectives] = useState<ExtractedObjective[]>([]);
@@ -39,13 +47,14 @@ export function ObjectivesPage() {
       if (!res.ok) throw new Error('server_error');
       const data = await res.json();
       console.log('Objectives received:', data.objectives);
-      const newObjectives = data.objectives.map((o: any) => ({
+      const newObjectives = data.objectives.map((o: ApiObjective) => ({
         id: o.id || generateId(),
         text: o.text,
-        cluster: o.cluster || 'General'
+        cluster: o.cluster || 'General',
       }));
       setObjectives(newObjectives);
       setEditedObjectives(newObjectives);
+      setGraph(data.graph ?? {});
       setText(''); // Clear input after successful extraction
     } catch (err) {
       console.error('Failed to load objectives', err);
@@ -72,29 +81,32 @@ export function ObjectivesPage() {
   };
 
   const updateObjective = (id: string, field: 'text' | 'cluster', value: string) => {
-    const updated = editedObjectives.map(obj => 
-      obj.id === id ? { ...obj, [field]: value } : obj
+    const updated = editedObjectives.map((obj) =>
+      obj.id === id ? { ...obj, [field]: value } : obj,
     );
     setEditedObjectives(updated);
   };
 
   const deleteObjective = (id: string) => {
-    const updated = editedObjectives.filter(obj => obj.id !== id);
+    const updated = editedObjectives.filter((obj) => obj.id !== id);
     setEditedObjectives(updated);
   };
 
   const addObjective = () => {
-    setEditedObjectives([...editedObjectives, { 
-      id: generateId(),
-      text: '', 
-      cluster: 'General' 
-    }]);
+    setEditedObjectives([
+      ...editedObjectives,
+      {
+        id: generateId(),
+        text: '',
+        cluster: 'General',
+      },
+    ]);
   };
 
   // Group objectives by cluster
   const groupObjectivesByCluster = (objs: ExtractedObjective[]) => {
     const grouped: { [cluster: string]: ExtractedObjective[] } = {};
-    objs.forEach(obj => {
+    objs.forEach((obj) => {
       if (!grouped[obj.cluster]) {
         grouped[obj.cluster] = [];
       }
@@ -105,7 +117,7 @@ export function ObjectivesPage() {
 
   // Get objective number by ID
   const getObjectiveNumber = (id: string) => {
-    const index = displayObjectives.findIndex(obj => obj.id === id);
+    const index = displayObjectives.findIndex((obj) => obj.id === id);
     return index + 1;
   };
 
@@ -120,7 +132,12 @@ export function ObjectivesPage() {
         <div className="builder-title-section">
           <button className="builder-back-button">
             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
             </svg>
           </button>
           <div>
@@ -144,12 +161,13 @@ export function ObjectivesPage() {
 
           <div className="builder-input-section">
             <p className="builder-helper-text">
-              Hi! I'll help you extract learning objectives from your course material. 
-              First, enter your course title below, then paste your course content in the bottom input.
+              Hi! I'll help you extract learning objectives from your course material.
+              First, enter your course title below, then paste your course content in the
+              bottom input.
             </p>
-            
+
             <p className="builder-question">What's the name of your course?</p>
-            
+
             <div className="builder-input-area">
               <input
                 className="builder-input"
@@ -157,11 +175,12 @@ export function ObjectivesPage() {
                 value={course}
                 onChange={(e) => setCourse(e.target.value)}
               />
-              
+
               {course && (
                 <div style={{ marginTop: '24px' }}>
                   <p className="builder-helper-text">
-                    Great! Now paste your course material in the input below and press Enter to extract objectives.
+                    Great! Now paste your course material in the input below and press
+                    Enter to extract objectives.
                   </p>
                 </div>
               )}
@@ -178,13 +197,18 @@ export function ObjectivesPage() {
                 onKeyDown={handleKeyDown}
                 rows={3}
               />
-              <button 
-                className="builder-send-button" 
+              <button
+                className="builder-send-button"
                 disabled={isDisabled}
                 onClick={extract}
               >
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
+                  />
                 </svg>
               </button>
             </div>
@@ -194,14 +218,18 @@ export function ObjectivesPage() {
         {/* Right Panel - Objectives by Cluster */}
         <div className="builder-right-panel">
           <div className="builder-preview-header">Objectives by Cluster</div>
-          
+
           <div className="builder-preview-content">
             {objectives.length === 0 && !loading && (
               <div className="builder-empty-preview">
                 <div className="builder-empty-icon">
                   <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
-                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                    />
                   </svg>
                 </div>
                 <p>Objectives will appear here grouped by cluster</p>
@@ -223,20 +251,26 @@ export function ObjectivesPage() {
                     <div className="builder-objectives-list">
                       {clusterObjectives.map((obj) => (
                         <div key={obj.id} className="builder-objective">
-                          <div className="builder-objective-number">{getObjectiveNumber(obj.id)}</div>
+                          <div className="builder-objective-number">
+                            {getObjectiveNumber(obj.id)}
+                          </div>
                           {isEditing ? (
                             <>
                               <div className="builder-objective-edit-fields">
                                 <input
                                   className="builder-objective-input"
                                   value={obj.text}
-                                  onChange={(e) => updateObjective(obj.id, 'text', e.target.value)}
+                                  onChange={(e) =>
+                                    updateObjective(obj.id, 'text', e.target.value)
+                                  }
                                   placeholder="Enter objective..."
                                 />
                                 <input
                                   className="builder-cluster-input"
                                   value={obj.cluster}
-                                  onChange={(e) => updateObjective(obj.id, 'cluster', e.target.value)}
+                                  onChange={(e) =>
+                                    updateObjective(obj.id, 'cluster', e.target.value)
+                                  }
                                   placeholder="Cluster name..."
                                 />
                               </div>
@@ -245,8 +279,17 @@ export function ObjectivesPage() {
                                 onClick={() => deleteObjective(obj.id)}
                                 title="Delete objective"
                               >
-                                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                <svg
+                                  fill="none"
+                                  stroke="currentColor"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M6 18L18 6M6 6l12 12"
+                                  />
                                 </svg>
                               </button>
                             </>
@@ -261,10 +304,27 @@ export function ObjectivesPage() {
                 {isEditing && (
                   <button className="builder-add-objective" onClick={addObjective}>
                     <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 4v16m8-8H4"
+                      />
                     </svg>
                     <span>Add objective</span>
                   </button>
+                )}
+                {Object.keys(graph).length > 0 && (
+                  <div className="builder-graph">
+                    <h3>Dependency Diagram</h3>
+                    <ul>
+                      {Object.entries(graph).map(([cluster, deps]) => (
+                        <li key={cluster}>
+                          {cluster}: {deps.length ? deps.join(', ') : 'none'}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
                 )}
               </div>
             )}
@@ -276,8 +336,12 @@ export function ObjectivesPage() {
               {!isEditing ? (
                 <button className="builder-edit-button" onClick={startEditing}>
                   <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
-                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                    />
                   </svg>
                   <span>Edit</span>
                 </button>

--- a/server/__tests__/extract.test.ts
+++ b/server/__tests__/extract.test.ts
@@ -12,7 +12,8 @@ beforeEach(() => {
 
 test('objective extractor returns objects', async () => {
   const text = await fs.readFile(samplePath, 'utf8');
-  nock('https://api.deepseek.com')
+  const llm = nock('https://api.deepseek.com');
+  llm
     .post('/v1/chat/completions')
     .reply(200, {
       choices: [
@@ -24,6 +25,10 @@ test('objective extractor returns objects', async () => {
           }
         }
       ]
+    })
+    .post('/v1/chat/completions')
+    .reply(200, {
+      choices: [{ message: { content: '{"Intro":[]}' } }]
     });
 
   const res = await request(app)
@@ -32,6 +37,7 @@ test('objective extractor returns objects', async () => {
 
   expect(res.status).toBe(200);
   expect(res.body.objectives[0].id).toBe('A-1');
+  expect(res.body.graph).toEqual({ Intro: [] });
 });
 
 

--- a/server/__tests__/graphRoute.test.ts
+++ b/server/__tests__/graphRoute.test.ts
@@ -32,3 +32,11 @@ test('POST /api/graph/generate validates objective shape', async () => {
     .send({ objectives: [{ bad: true }] });
   expect(res.status).toBe(400);
 });
+
+test('POST /api/graph/generate rejects blank fields', async () => {
+  const res = await request(app)
+    .post('/api/graph/generate')
+    .send({ objectives: [{ id: ' ', text: 'a', bloom: '', cluster: 'Intro' }] });
+
+  expect(res.status).toBe(400);
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,7 +36,8 @@ app.post('/api/objectives/extract', async (req, res) => {
     console.log('Extracting objectives for', course);
     const objectives = await extractObjectives(course, text);
     console.log('Objectives extracted:', objectives.length);
-    res.json({ objectives });
+    const graph = await generateClusterGraph(objectives);
+    res.json({ objectives, graph });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'llm_error' });
@@ -54,7 +55,12 @@ app.post('/api/graph/generate', async (req, res) => {
         !o ||
         typeof o.id !== 'string' ||
         typeof o.text !== 'string' ||
-        typeof o.cluster !== 'string'
+        typeof o.bloom !== 'string' ||
+        typeof o.cluster !== 'string' ||
+        !o.id.trim() ||
+        !o.text.trim() ||
+        !o.bloom.trim() ||
+        !o.cluster.trim()
     )
   ) {
     return res.status(400).json({ error: 'invalid objectives' });


### PR DESCRIPTION
### **User description**
## Summary
- avoid using `any` when processing extracted objectives
- merge latest main to include graph features

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6845e1c760d88330a768dce669b6f496


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add dependency graph extraction and display to objectives workflow
  - API now returns a cluster dependency graph with objectives
  - UI displays the dependency graph in ObjectivesPage

- Enforce stricter validation for objective fields in backend
  - All objective fields must be non-empty strings
  - Tests added for blank field rejection

- Update and expand tests for objective extraction and graph generation
  - Mock LLM responses for both objectives and graph
  - Add test for blank field rejection in graph API

- Update documentation to reflect API and validation changes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ObjectivesPage.tsx</strong><dd><code>Display cluster dependency graph and improve objectives handling</code></dd></summary>
<hr>

client/src/ObjectivesPage.tsx

<li>Add <code>graph</code> state and display dependency graph in UI<br> <li> Update API call to handle and store returned graph<br> <li> Refactor for stricter typing and improved formatting<br> <li> Enhance editing and grouping logic for objectives


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/54/files#diff-4d2135bfd43806c067914b9c9d83b3e00696a582f71c9072ba019f0a95641e09">+98/-34</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Return graph and enforce strict objective validation in API</code></dd></summary>
<hr>

server/src/index.ts

<li>API now returns both objectives and dependency graph<br> <li> Enforce all objective fields are non-empty strings in validation<br> <li> Update error handling for invalid objectives


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/54/files#diff-c299744f73df4daa7a22854dda2023b68bfc8a5d59d8fb90b3a53b0c2842d807">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>extract.test.ts</strong><dd><code>Test objectives and graph extraction from API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/__tests__/extract.test.ts

<li>Mock LLM to return both objectives and graph<br> <li> Assert graph is present in API response<br> <li> Improve test clarity and coverage


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/54/files#diff-e8de4eede8dc270369477dba19bbdd9f7822095b3ac394376952dfa81b5b990b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graphRoute.test.ts</strong><dd><code>Add test for blank objective field rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/__tests__/graphRoute.test.ts

<li>Add test for rejection of blank objective fields<br> <li> Ensure API returns 400 for invalid input


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/54/files#diff-4d221365a176a98c3497085a2b763597dc7bfeda6dbb1656d7446cc5dae3f2f2">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document dependency graph API and validation requirements</code></dd></summary>
<hr>

README.md

<li>Document that objective extraction returns a dependency graph<br> <li> Clarify that all objective fields must be non-empty strings<br> <li> Add section for dependency graph API


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/54/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>