### PR TITLE
Improve graphGenerator coverage

### DIFF
--- a/server/__tests__/graphGenerator.errors.test.ts
+++ b/server/__tests__/graphGenerator.errors.test.ts
@@ -1,0 +1,26 @@
+import { generateClusterGraph } from '../src/llm/graphGenerator';
+import { deepSeekChat } from '../src/llm/deepseek';
+import { ExtractedObjective } from '../src/objectives';
+
+jest.mock('../src/llm/deepseek', () => ({
+  deepSeekChat: jest.fn(),
+}));
+
+const mockChat = deepSeekChat as jest.Mock;
+const objectives: ExtractedObjective[] = [
+  { id: 'A1', text: 'Define X', bloom: 'Remember', cluster: 'Intro' },
+];
+
+beforeEach(() => {
+  mockChat.mockReset();
+});
+
+test('throws when parsed JSON is not an object', async () => {
+  mockChat.mockResolvedValue({ choices: [{ message: { content: '[]' } }] });
+  await expect(generateClusterGraph(objectives)).rejects.toThrow('invalid graph');
+});
+
+test('throws when cluster values are not arrays of strings', async () => {
+  mockChat.mockResolvedValue({ choices: [{ message: { content: '{"Intro":[1]}' } }] });
+  await expect(generateClusterGraph(objectives)).rejects.toThrow('invalid graph');
+});


### PR DESCRIPTION
### **User description**
## Summary
- add tests for graphGenerator error handling

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm exec jest --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6845f3ecebfc833089b669970fbe3383


___

### **PR Type**
Tests


___

### **Description**
- Add tests for `graphGenerator` error handling scenarios

- Mock `deepSeekChat` to simulate invalid graph responses

- Ensure exceptions are thrown for malformed graph data


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graphGenerator.errors.test.ts</strong><dd><code>Add tests for graphGenerator error scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/__tests__/graphGenerator.errors.test.ts

<li>Introduced new test file for <code>graphGenerator</code> error cases<br> <li> Mocked <code>deepSeekChat</code> to return invalid graph data<br> <li> Added tests to verify exceptions for non-object and invalid cluster <br>values


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/56/files#diff-e3fe3500790b5231154500a821ed16e2a49273fd6d9dd12e0cbd35aeefb3fb6a">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>