### PR TITLE
Add objective practice workflow

### DIFF
--- a/client/__tests__/practiceApi.test.ts
+++ b/client/__tests__/practiceApi.test.ts
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+import { generatePracticeItem, gradePracticeAnswer } from '../src/api';
+import { initAnonUser } from '../src/auth';
+
+beforeEach(() => {
+  localStorage.clear();
+  Object.defineProperty(globalThis, 'fetch', {
+    writable: true,
+    configurable: true,
+    value: jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) })),
+  });
+});
+
+test('generatePracticeItem posts objective', async () => {
+  initAnonUser();
+  await generatePracticeItem('O', 1);
+  const call = (global.fetch as jest.Mock).mock.calls[0];
+  expect(call[0]).toBe('/api/practice/question');
+  const opts = call[1];
+  expect(opts.method).toBe('POST');
+});
+
+test('gradePracticeAnswer posts answer', async () => {
+  initAnonUser();
+  await gradePracticeAnswer('Q', 'A', 'B');
+  const call = (global.fetch as jest.Mock).mock.calls[0];
+  expect(call[0]).toBe('/api/practice/grade');
+  const opts = call[1];
+  expect(opts.method).toBe('POST');
+});

--- a/client/src/ObjectivePractice.tsx
+++ b/client/src/ObjectivePractice.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { generatePracticeItem, gradePracticeAnswer } from './api';
+
+interface Props {
+  objective: string;
+  onBack: () => void;
+}
+
+export function ObjectivePractice({ objective, onBack }: Props) {
+  const [tier, setTier] = useState<number | null>(null);
+  const [stem, setStem] = useState('');
+  const [reference, setReference] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [result, setResult] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const start = async (t: number) => {
+    setLoading(true);
+    const item = await generatePracticeItem(objective, t);
+    setStem(item.stem);
+    setReference(item.reference);
+    setTier(t);
+    setLoading(false);
+  };
+
+  const submit = async () => {
+    setLoading(true);
+    const res = await gradePracticeAnswer(stem, reference, answer);
+    setResult(res.verdict + (res.feedback ? `: ${res.feedback}` : ''));
+    setLoading(false);
+  };
+
+  if (tier === null) {
+    return (
+      <div>
+        <h2>Select difficulty</h2>
+        {[1, 3, 5].map((t) => (
+          <button key={t} onClick={() => start(t)} disabled={loading}>
+            Tier {t}
+          </button>
+        ))}
+        <button onClick={onBack}>Back</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p>{stem}</p>
+      <textarea value={answer} onChange={(e) => setAnswer(e.target.value)} />
+      <button onClick={submit} disabled={loading}>
+        Submit
+      </button>
+      {result && <div role="alert">{result}</div>}
+      <button onClick={onBack}>Back</button>
+    </div>
+  );
+}

--- a/client/src/ObjectivesPage.tsx
+++ b/client/src/ObjectivesPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { apiFetch } from './api';
+import { ObjectivePractice } from './ObjectivePractice';
 import './chatgpt-theme.css';
 
 interface ExtractedObjective {
@@ -29,6 +30,7 @@ export function ObjectivesPage() {
   const [isEditing, setIsEditing] = useState(false);
   const [editedObjectives, setEditedObjectives] = useState<ExtractedObjective[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>('objectives');
+  const [practiceObj, setPracticeObj] = useState<ExtractedObjective | null>(null);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -127,6 +129,15 @@ export function ObjectivesPage() {
   const isDisabled = loading || !text.trim() || !course.trim();
   const displayObjectives = isEditing ? editedObjectives : objectives;
   const groupedObjectives = groupObjectivesByCluster(displayObjectives);
+
+  if (practiceObj) {
+    return (
+      <ObjectivePractice
+        objective={practiceObj.text}
+        onBack={() => setPracticeObj(null)}
+      />
+    );
+  }
 
   return (
     <div className="builder-container">
@@ -342,7 +353,13 @@ export function ObjectivesPage() {
                               </button>
                             </>
                           ) : (
-                            <p className="builder-objective-text">{obj.text}</p>
+                            <p
+                              className="builder-objective-text"
+                              onClick={() => setPracticeObj(obj)}
+                              style={{ cursor: 'pointer' }}
+                            >
+                              {obj.text}
+                            </p>
                           )}
                         </div>
                       ))}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -25,3 +25,25 @@ export async function submitAnswer(itemId: number, answer: string) {
   });
   return res.json();
 }
+
+export async function generatePracticeItem(objective: string, tier: number) {
+  const res = await apiFetch('/api/practice/question', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ objective, tier }),
+  });
+  return res.json();
+}
+
+export async function gradePracticeAnswer(
+  stem: string,
+  reference: string,
+  answer: string,
+) {
+  const res = await apiFetch('/api/practice/grade', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ stem, reference, answer }),
+  });
+  return res.json();
+}

--- a/server/__tests__/practiceRoute.test.ts
+++ b/server/__tests__/practiceRoute.test.ts
@@ -1,0 +1,35 @@
+import request from 'supertest';
+import { app } from '../src/index';
+import { generateItem } from '../src/llm/itemGenerator';
+import { gradeFreeResponse } from '../src/llm/grader';
+
+jest.mock('../src/llm/itemGenerator', () => ({ generateItem: jest.fn() }));
+jest.mock('../src/llm/grader', () => ({ gradeFreeResponse: jest.fn() }));
+
+const mockGen = generateItem as jest.Mock;
+const mockGrade = gradeFreeResponse as jest.Mock;
+
+beforeEach(() => {
+  mockGen.mockReset();
+  mockGrade.mockReset();
+});
+
+test('POST /api/practice/question returns item', async () => {
+  mockGen.mockResolvedValue({ stem: 'Q', reference: 'A' });
+  const res = await request(app)
+    .post('/api/practice/question')
+    .send({ objective: 'Obj', tier: 1 });
+  expect(res.status).toBe(200);
+  expect(res.body.stem).toBe('Q');
+  expect(mockGen).toHaveBeenCalled();
+});
+
+test('POST /api/practice/grade returns verdict', async () => {
+  mockGrade.mockResolvedValue({ verdict: 'correct', score: 1, modelVotes: [] });
+  const res = await request(app)
+    .post('/api/practice/grade')
+    .send({ stem: 'Q', reference: 'A', answer: 'A' });
+  expect(res.status).toBe(200);
+  expect(res.body.verdict).toBe('correct');
+  expect(mockGrade).toHaveBeenCalled();
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ import { extractObjectives } from './objectives';
 import { generateClusterGraph } from './llm/graphGenerator';
 import { adminRouter } from './admin';
 import { courseRouter } from './courses';
+import { practiceRouter } from './practice';
 
 // Express server exposing health check and upload route.
 export const app = express();
@@ -14,6 +15,7 @@ app.use(cors());
 app.use(express.json());
 app.use('/api', adminRouter);
 app.use('/api/courses', courseRouter);
+app.use('/api/practice', practiceRouter);
 
 app.post('/api/upload', async (req, res) => {
   const text = req.body.text;

--- a/server/src/practice.ts
+++ b/server/src/practice.ts
@@ -1,0 +1,53 @@
+import express from 'express';
+import { generateItem } from './llm/itemGenerator';
+import { gradeFreeResponse } from './llm/grader';
+
+export const practiceRouter = express.Router();
+
+practiceRouter.post('/question', async (req, res) => {
+  const { objective, tier } = req.body as { objective?: string; tier?: number };
+  if (typeof objective !== 'string' || !objective.trim()) {
+    return res.status(400).json({ error: 'objective required' });
+  }
+  if (typeof tier !== 'number' || ![1, 3, 5].includes(tier)) {
+    return res.status(400).json({ error: 'tier invalid' });
+  }
+  try {
+    const item = await generateItem({
+      objective,
+      bloom: 'Remember',
+      tier,
+      context: '',
+      previous: [],
+    });
+    res.json({ stem: item.stem, reference: item.reference });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'llm_error' });
+  }
+});
+
+practiceRouter.post('/grade', async (req, res) => {
+  const { stem, reference, answer } = req.body as {
+    stem?: string;
+    reference?: string;
+    answer?: string;
+  };
+  if (typeof stem !== 'string' || !stem.trim()) {
+    return res.status(400).json({ error: 'stem required' });
+  }
+  if (typeof reference !== 'string') {
+    return res.status(400).json({ error: 'reference required' });
+  }
+  if (typeof answer !== 'string') {
+    return res.status(400).json({ error: 'answer required' });
+  }
+  try {
+    const prompt = `${stem}\nReference answer: ${reference}`;
+    const result = await gradeFreeResponse(prompt, answer);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'llm_error' });
+  }
+});


### PR DESCRIPTION
## Summary
- create `/api/practice` router to generate questions and grade answers
- expose new practice API helpers to the client
- add `ObjectivePractice` component for ad‑hoc questions
- integrate practice view into `ObjectivesPage`
- test new API helpers and practice endpoints

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6846022680348330a7ccb07a4c4e14cc