### PR TITLE
Add manual session question route

### DIFF
--- a/client/src/ObjectivePractice.tsx
+++ b/client/src/ObjectivePractice.tsx
@@ -44,7 +44,12 @@ export function ObjectivePractice({ objective, onBack }: Props) {
         <header className="practice-header">
           <button className="practice-back-button" onClick={onBack}>
             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
             </svg>
           </button>
           <div className="practice-title-section">
@@ -64,17 +69,25 @@ export function ObjectivePractice({ objective, onBack }: Props) {
             <p className="difficulty-description">
               Choose how challenging you want the practice question to be
             </p>
-            
+
             <div className="difficulty-options">
               {[
-                { tier: 1, name: 'Basic', description: 'Fundamental concepts and recall' },
-                { tier: 3, name: 'Intermediate', description: 'Application and analysis' },
-                { tier: 5, name: 'Advanced', description: 'Synthesis and evaluation' }
+                {
+                  tier: 1,
+                  name: 'Basic',
+                  description: 'Fundamental concepts and recall',
+                },
+                {
+                  tier: 3,
+                  name: 'Intermediate',
+                  description: 'Application and analysis',
+                },
+                { tier: 5, name: 'Advanced', description: 'Synthesis and evaluation' },
               ].map(({ tier: t, name, description }) => (
-                <button 
-                  key={t} 
+                <button
+                  key={t}
                   className={`difficulty-card ${loading ? 'disabled' : ''}`}
-                  onClick={() => start(t)} 
+                  onClick={() => start(t)}
                   disabled={loading}
                 >
                   <div className="difficulty-tier">Tier {t}</div>
@@ -94,7 +107,12 @@ export function ObjectivePractice({ objective, onBack }: Props) {
       <header className="practice-header">
         <button className="practice-back-button" onClick={onBack}>
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
         </button>
         <div className="practice-title-section">
@@ -112,19 +130,19 @@ export function ObjectivePractice({ objective, onBack }: Props) {
 
           <div className="answer-section">
             <label className="answer-label">Your Answer</label>
-            <textarea 
+            <textarea
               className="answer-input"
-              value={answer} 
+              value={answer}
               onChange={(e) => setAnswer(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="Type your answer here..."
               rows={6}
               disabled={loading}
             />
-            
-            <button 
+
+            <button
               className={`submit-button ${loading || !answer.trim() ? 'disabled' : ''}`}
-              onClick={submit} 
+              onClick={submit}
               disabled={loading || !answer.trim()}
             >
               {loading ? (
@@ -136,7 +154,12 @@ export function ObjectivePractice({ objective, onBack }: Props) {
                 <>
                   <span>Submit Answer</span>
                   <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M13 7l5 5m0 0l-5 5m5-5H6"
+                    />
                   </svg>
                 </>
               )}
@@ -144,15 +167,27 @@ export function ObjectivePractice({ objective, onBack }: Props) {
           </div>
 
           {result && (
-            <div className={`result-section ${result.startsWith('Correct') ? 'correct' : 'incorrect'}`}>
+            <div
+              className={`result-section ${result.startsWith('Correct') ? 'correct' : 'incorrect'}`}
+            >
               <div className="result-icon">
                 {result.startsWith('Correct') ? (
                   <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
                   </svg>
                 ) : (
                   <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
                   </svg>
                 )}
               </div>

--- a/server/__tests__/sessionRoute.test.ts
+++ b/server/__tests__/sessionRoute.test.ts
@@ -1,0 +1,26 @@
+import request from 'supertest';
+import { app } from '../src/index';
+import { generateItem } from '../src/llm/itemGenerator';
+
+jest.mock('../src/llm/itemGenerator', () => ({ generateItem: jest.fn() }));
+
+const mockGen = generateItem as jest.Mock;
+
+beforeEach(() => {
+  mockGen.mockReset();
+});
+
+test('POST /api/session/manual-question returns item', async () => {
+  mockGen.mockResolvedValue({ stem: 'Q', reference: 'A' });
+  const res = await request(app)
+    .post('/api/session/manual-question')
+    .send({ objective: 'Obj', difficulty: 'easy' });
+  expect(res.status).toBe(200);
+  expect(res.body.stem).toBe('Q');
+  expect(mockGen).toHaveBeenCalled();
+});
+
+test('POST /api/session/manual-question validates input', async () => {
+  const res = await request(app).post('/api/session/manual-question').send({});
+  expect(res.status).toBe(400);
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import { generateClusterGraph } from './llm/graphGenerator';
 import { adminRouter } from './admin';
 import { courseRouter } from './courses';
 import { practiceRouter } from './practice';
+import { sessionRouter } from './session';
 
 // Express server exposing health check and upload route.
 export const app = express();
@@ -16,6 +17,7 @@ app.use(express.json());
 app.use('/api', adminRouter);
 app.use('/api/courses', courseRouter);
 app.use('/api/practice', practiceRouter);
+app.use('/api/session', sessionRouter);
 
 app.post('/api/upload', async (req, res) => {
   const text = req.body.text;

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -1,0 +1,35 @@
+import express from 'express';
+import { generateItem } from './llm/itemGenerator';
+
+// Session routes for learner flow.
+// The manual-question endpoint bypasses the Scheduler and directly
+// generates an item for the given objective and difficulty.
+export const sessionRouter = express.Router();
+
+sessionRouter.post('/manual-question', async (req, res) => {
+  const { objective, difficulty } = req.body as {
+    objective?: string;
+    difficulty?: string;
+  };
+  if (typeof objective !== 'string' || !objective.trim()) {
+    return res.status(400).json({ error: 'objective required' });
+  }
+  const diffMap: Record<string, number> = { easy: 1, medium: 3, hard: 5 };
+  const tier = diffMap[(difficulty || '').toLowerCase()];
+  if (!tier) {
+    return res.status(400).json({ error: 'difficulty invalid' });
+  }
+  try {
+    const item = await generateItem({
+      objective,
+      bloom: 'Remember',
+      tier,
+      context: '',
+      previous: [],
+    });
+    res.json({ stem: item.stem, reference: item.reference });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'llm_error' });
+  }
+});


### PR DESCRIPTION
### **User description**
## Summary
- add `/api/session/manual-question` for generating an item without the Scheduler
- mount new router in the API server
- test the manual question route

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68460bdba0f083309f0f8c0e25490c5b


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `/api/session/manual-question` endpoint for manual question generation
  - Accepts `objective` and `difficulty`, validates input
  - Calls `generateItem` directly, bypassing Scheduler
  - Returns generated item's `stem` and `reference`
  - Handles input validation and LLM errors

- Integrate new session router into main API server

- Add tests for manual question endpoint
  - Test successful item generation
  - Test input validation error handling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session.ts</strong><dd><code>Add session router with manual question generation endpoint</code></dd></summary>
<hr>

server/src/session.ts

<li>Introduces <code>sessionRouter</code> with <code>/manual-question</code> POST endpoint<br> <li> Validates <code>objective</code> and <code>difficulty</code> in request body<br> <li> Calls <code>generateItem</code> and returns result or error<br> <li> Handles and logs LLM errors


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/63/files#diff-6d7e0b77ea9f647164408127e888b572a0a1f21a7d5c4ad4100a45e9a022f3cb">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Integrate session router into API server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/index.ts

<li>Imports and mounts <code>sessionRouter</code> at <code>/api/session</code><br> <li> Integrates new session routes into API server


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/63/files#diff-c299744f73df4daa7a22854dda2023b68bfc8a5d59d8fb90b3a53b0c2842d807">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sessionRoute.test.ts</strong><dd><code>Add tests for manual session question endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/__tests__/sessionRoute.test.ts

<li>Adds tests for <code>/api/session/manual-question</code> endpoint<br> <li> Mocks <code>generateItem</code> for controlled test behavior<br> <li> Tests both successful and invalid input cases


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/63/files#diff-78387971d87fb1f035cc4c07bdd0bf8bef940de94b33c50683eaa29c059fa7d0">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>