### PR TITLE
Use groupBy for unseen scheduler query

### DIFF
--- a/server/src/scheduler.ts
+++ b/server/src/scheduler.ts
@@ -22,13 +22,13 @@ export async function getDue(userId: number): Promise<number[]> {
  * Earliest unseen item per objective.
  */
 export async function getFirstUnseen(userId: number): Promise<number[]> {
-  const items = await db.item.findMany({
+  const groups = await db.item.groupBy({
+    by: ['objectiveId'],
     where: { states: { none: { userId } } },
-    orderBy: { id: 'asc' },
-    distinct: ['objectiveId'],
-    select: { id: true },
+    _min: { id: true },
+    orderBy: { objectiveId: 'asc' },
   });
-  return items.map((i) => i.id);
+  return groups.map((g) => g._min.id!);
 }
 
 /**


### PR DESCRIPTION
### **User description**
## Summary
- replace scheduler `findMany` call with `groupBy`
- keep results ordered by objective

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684f2061ddac8330ad0cdd8ba4c8cadd


___

### **PR Type**
Enhancement


___

### **Description**
• Replace `findMany` with `groupBy` for unseen scheduler query
• Maintain ordering by objective ID instead of item ID
• Optimize database query performance for earliest unseen items


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduler.ts</strong><dd><code>Optimize unseen items query with groupBy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/scheduler.ts

• Replace <code>db.item.findMany</code> with <code>db.item.groupBy</code> in <code>getFirstUnseen</code> <br>function<br> • Use <code>_min: { id: true }</code> to get earliest item per objective<br> • <br>Change ordering from <code>{ id: 'asc' }</code> to <code>{ objectiveId: 'asc' }</code><br> • Update <br>result mapping to access <code>g._min.id!</code> instead of <code>i.id</code>


</details>


  </td>
  <td><a href="https://github.com/cmkourtu/testme/pull/72/files#diff-489fb13c461371c0b8d30eb7ee4b86bf613b26ac05b4a72019f42e16ad04b252">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>